### PR TITLE
[fix]: Range is undefined in menu.ts example

### DIFF
--- a/menu.ts
+++ b/menu.ts
@@ -42,7 +42,7 @@ mainMenu.dynamic(() =>
   dishDatabase.reduce(addDishToDynamicRange, new MenuRange<MyContext>())
 );
 function addDishToDynamicRange(range: MenuRange<MyContext>, dish: Dish) {
-  return range
+  return MenuRange
     .submenu(
       { text: dish.name, payload: dish.id }, // label and payload
       "dish", // navigation target menu


### PR DESCRIPTION
**Description**

When you run the `menu.ts`example, appears the error `Unknown error: ReferenceError: range is not defined´

This is caused because you are trying to use `range` parameter, but it's defined as `MenuRange`

```
function addDishToDynamicRange(MenuRange, dish) {
    return range
        .submenu(
            { text: dish.name, payload: dish.id }, // label and payload
            "dish", // navigation target menu
            (ctx) => ctx.editMessageText(dishText(dish.name), { parse_mode: "HTML" }), // handler
        )
        .row()
}
```