### PR TITLE
Update Vercel bot to use correct webhook adapter

### DIFF
--- a/vercel-bot/api/index.ts
+++ b/vercel-bot/api/index.ts
@@ -10,4 +10,4 @@ bot.on("message", async (ctx) => {
 
 // The free version of vercel has restrictions on quotas, which we need to enable in the configuration file vercel.json
 // webhookCallback will make sure that the correct middleware(listener) function is called
-export default webhookCallback(bot, 'express')
+export default webhookCallback(bot, 'http')


### PR DESCRIPTION
Vercel's documentation on serverless functions state that the request
and response objects are, respesctively, `IncomingMessage` and
`ServerResponse` objects, which is confirmed by their types.

That makes it so the best adapter to use with Vercel is the one used
for Node's `http` module.

Fixes [#239](https://github.com/grammyjs/grammY/issues/239)