### PR TITLE
chore: update deno deploy example

### DIFF
--- a/setups/deno-deploy/deps.deno.ts
+++ b/setups/deno-deploy/deps.deno.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/grammy@v1.8.3/mod.ts";
+export * from "https://deno.land/x/grammy@v1.27.0/mod.ts";

--- a/setups/deno-deploy/server.ts
+++ b/setups/deno-deploy/server.ts
@@ -1,10 +1,9 @@
-import { serve } from "https://deno.land/std@0.154.0/http/server.ts";
 import { bot } from "./bot.ts";
 import { webhookCallback } from "./deps.deno.ts";
 
 const handleUpdate = webhookCallback(bot, "std/http");
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method == "POST") {
     const url = new URL(req.url);
     if (url.pathname.slice(1) == bot.token) {


### PR DESCRIPTION
* Updates Deno Deploy example as `serve` is being deprecated.
See https://deno.land/std@0.224.0/http/server.ts?s=serve
* Bumps grammY version 